### PR TITLE
Executable name in launch_script.bat.in not correct

### DIFF
--- a/resources/templates/launch_script.bat.in
+++ b/resources/templates/launch_script.bat.in
@@ -17,7 +17,7 @@
 setlocal EnableDelayedExpansion
 
 set appName=${LAUNCH_EXECUTABLE_NAME}
-set executableName=${LAUNCH_EXECUTABLE_NAME}app.exe
+set executableName=${LAUNCH_EXECUTABLE_NAME}.exe
 set scriptVersion=${CONNEXTDDS_VERSION}
 
 set dir=%~dp0


### PR DESCRIPTION
As per title. The `app` part can be omitted from the `executableName`. 

In addition, to be able to run the `./rtiddsopcuagateway -cfgName default` command, I had to make sure the following environment variables where set:
- `NDDSHOME=C:\Program Files\rti_connext_dds-6.1.0`
- `RTI_LICENSE_FILE=C:\Program Files\rti_connext_dds-6.1.0\rti_license.dat`
- Add to `Path`: `%NDDSHOME%\lib\x64Win64VS2017\` and `%NDDSHOME%\bin`